### PR TITLE
Make publiccode.yml valid

### DIFF
--- a/publiccode.yml
+++ b/publiccode.yml
@@ -9,7 +9,6 @@ categories:
   - office
 description:
   it:
-    documentation: 'https://rubydoc.info/github/isprambiente/medplan/master'
     features:
       - gestione dipendenti
       - gestione appuntamenti


### PR DESCRIPTION
Remove the link to https://rubydoc.info/github/isprambiente/medplan/master
as it's a 404 and prevents the software to enter the Software Catalog.